### PR TITLE
Error on setBitmap method

### DIFF
--- a/app/src/main/java/com/tutsplus/facedetection/FaceOverlayView.java
+++ b/app/src/main/java/com/tutsplus/facedetection/FaceOverlayView.java
@@ -38,6 +38,7 @@ public class FaceOverlayView extends View {
 
     public void setBitmap( Bitmap bitmap ) {
         mBitmap = bitmap;
+        Frame frame;
         FaceDetector detector = new FaceDetector.Builder( getContext() )
                 .setTrackingEnabled(true)
                 .setLandmarkType(FaceDetector.ALL_LANDMARKS)
@@ -47,7 +48,7 @@ public class FaceOverlayView extends View {
         if (!detector.isOperational()) {
             //Handle contingency
         } else {
-            Frame frame = new Frame.Builder().setBitmap(bitmap).build();
+            frame = new Frame.Builder().setBitmap(bitmap).build();
             mFaces = detector.detect(frame);
             detector.release();
         }


### PR DESCRIPTION
Inside the setBitmap method, the scope for the variable frame ends once the else block finishes. Thus, calling logFaceData would have no purpose without having a Frame. To fix this either declare the variable frame outside of the else block or call the logFaceData() inside of the else block. In this case, I have chosen to declare the variable frame outside of the else block.
